### PR TITLE
Add package json and depend on get-style-property

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "get-size",
+  "version": "1.1.7",
+  "description": "measures element size",
+  "main": "get-size.js",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/desandro/get-size.git"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/desandro/get-size/issues"
+  },
+  "homepage": "https://github.com/desandro/get-size",
+  "dependencies": {
+    "get-style-property": "https://github.com/wbinnssmith/get-style-property/archive/packagejson.tar.gz"
+  }
+}


### PR DESCRIPTION
This lets commonjs bundlers find the entry point.

It also adds the dependendency on get-style-property. Right now it's pointed at my fork but if it gets merged into get-size (or even better published to npm), the dependency can be updated!
