### PR TITLE
Avoid calling indexOf on null values

### DIFF
--- a/get-size.js
+++ b/get-size.js
@@ -26,7 +26,7 @@ var getStyle = getComputedStyle ?
 function getStyleSize( value ) {
   var num = parseFloat( value );
   // not a percent like '100%', and a number
-  var isValid = value.indexOf('%') === -1 && !isNaN( num );
+  var isValid = !isNaN( num ) && value.indexOf('%') === -1;
   return isValid && num;
 }
 


### PR DESCRIPTION
I've been using Masonry in a project, which uses this library for size checking. On iOS, for whatever reason, it would try and get the size of a null property. Calling indexOf on null produced an error. By reversing the order in which the statements are evaluated by letting isNaN( parseFloat( null ) ) short circuit the statement.
